### PR TITLE
Paging for MsSql2012 changed to the new recommended standard syntax (Update to #78)

### DIFF
--- a/src/NHibernate/Dialect/MsSql2005Dialect.cs
+++ b/src/NHibernate/Dialect/MsSql2005Dialect.cs
@@ -2,6 +2,7 @@ using System.Data;
 using NHibernate.Driver;
 using NHibernate.Mapping;
 using NHibernate.SqlCommand;
+using NHibernate.Dialect.Function;
 
 namespace NHibernate.Dialect
 {
@@ -32,6 +33,13 @@ namespace NHibernate.Dialect
 			base.RegisterKeywords();
 			RegisterKeyword("xml");
 		}
+
+        protected override void RegisterFunctions()
+        {
+            base.RegisterFunctions();
+            RegisterFunction("extract", new SQLFunctionTemplate(NHibernateUtil.Int32, "datepart(?1, ?3)"));
+            RegisterFunction("bit_length", new SQLFunctionTemplate(NHibernateUtil.Int32, "datalength(?1) * 8"));
+        }
 
 		public override SqlString GetLimitString(SqlString queryString, SqlString offset, SqlString limit)
 		{

--- a/src/NHibernate/Dialect/MsSql2012Dialect.cs
+++ b/src/NHibernate/Dialect/MsSql2012Dialect.cs
@@ -1,0 +1,67 @@
+﻿using System.Data;
+using System.Collections.Generic;
+using NHibernate.Cfg;
+using NHibernate.Dialect.Function;
+using NHibernate.Driver;
+using NHibernate.SqlCommand;
+
+namespace NHibernate.Dialect
+{
+	public class MsSql2012Dialect : MsSql2008Dialect
+	{
+        public override SqlString GetLimitString(SqlString queryString, SqlString offset, SqlString limit)
+        {
+            var result = new SqlStringBuilder(queryString);
+
+            int orderIndex = queryString.LastIndexOfCaseInsensitive(" order by ");
+
+            //don't use the order index if it is contained within a larger statement(assuming
+            //a statement with non matching parenthesis is part of a larger block)
+            if (orderIndex < 0 || !HasMatchingParens(queryString.Substring(orderIndex).ToString()))
+            {
+                // Use order by first column if no explicit ordering is provided
+                result.Add( " ORDER BY ")
+                    .Add("1");
+            }
+
+            result.Add(" OFFSET ")
+                .Add(offset ?? new SqlString("0"))
+                .Add(" ROWS");
+
+            if (limit != null) 
+            {
+                result.Add(" FETCH FIRST ").Add(limit).Add(" ROWS ONLY");
+            }
+
+            return result.ToSqlString();
+        }
+
+        /// <summary>
+        /// Indicates whether the string fragment contains matching parenthesis
+        /// </summary>
+        /// <param name="statement"> the statement to evaluate</param>
+        /// <returns>true if the statment contains no parenthesis or an equal number of
+        ///  opening and closing parenthesis;otherwise false </returns>
+        private static bool HasMatchingParens(IEnumerable<char> statement)
+        {
+            //unmatched paren count
+            int unmatchedParen = 0;
+
+            //increment the counts based in the opening and closing parens in the statement
+            foreach (char item in statement)
+            {
+                switch (item)
+                {
+                    case '(':
+                        unmatchedParen++;
+                        break;
+                    case ')':
+                        unmatchedParen--;
+                        break;
+                }
+            }
+
+            return unmatchedParen == 0;
+        }
+    }
+}

--- a/src/NHibernate/NHibernate.csproj
+++ b/src/NHibernate/NHibernate.csproj
@@ -134,6 +134,7 @@
     <Compile Include="Connection\IConnectionProvider.cs" />
     <Compile Include="Connection\UserSuppliedConnectionProvider.cs" />
     <Compile Include="Criterion\IEnhancedProjection.cs" />
+    <Compile Include="Dialect\MsSql2012Dialect.cs" />
     <Compile Include="Dialect\DB2Dialect.cs" />
     <Compile Include="Dialect\Dialect.cs" />
     <Compile Include="Dialect\FirebirdDialect.cs" />


### PR DESCRIPTION
Created new MSSQL2012 Dialect. Implemented new paging syntax with
select xxx from yyy order by zzz offset @p1 rows fetch first @p2 rows only
Existing paging unit tests work fine with it.

Updated because of the significant changes in MSSQL2005 dialect requiring additional work for pulling that change.

https://nhibernate.jira.com/browse/NH-3038
